### PR TITLE
v0.1.1 - Made the CSharpGenerator accept an ICompilation instead of the concrete type

### DIFF
--- a/src/Devantler.Commons.AutoFixture.DataAttributes/AutoNSubstituteData.cs
+++ b/src/Devantler.Commons.AutoFixture.DataAttributes/AutoNSubstituteData.cs
@@ -4,8 +4,15 @@ using AutoFixture.Xunit2;
 
 namespace Devantler.Commons.AutoFixture.DataAttributes;
 
+/// <summary>
+/// A data attribute that uses AutoFixture and NSubstitute to generate data and create mocks for tests.
+/// </summary>
 public class AutoNSubstituteDataAttribute : AutoDataAttribute
 {
+    /// <summary>
+    /// Creates a new instance of the <see cref="AutoNSubstituteDataAttribute"/> class.
+    /// </summary>
+    /// <param name="customizations"></param>
     public AutoNSubstituteDataAttribute(params Type[] customizations) : base(
         () => new Fixture()
             .Customize(new AutoNSubstituteCustomization())

--- a/src/Devantler.Commons.AutoFixture.DataAttributes/Devantler.Commons.AutoFixture.DataAttributes.csproj
+++ b/src/Devantler.Commons.AutoFixture.DataAttributes/Devantler.Commons.AutoFixture.DataAttributes.csproj
@@ -9,7 +9,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <PackageId>Devantler.Commons.AutoFixture.DataAttributes</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>devantler</Authors>
         <Company>Devantler Software</Company>
         <PackageDescription>Common AutoFixture data attributes for Xunit and NSubstitute.</PackageDescription>

--- a/src/Devantler.Commons.CodeGen.CSharp/CSharpCodeGenerator.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/CSharpCodeGenerator.cs
@@ -1,13 +1,12 @@
 using Devantler.Commons.CodeGen.Core.Interfaces;
-using Devantler.Commons.CodeGen.CSharp.Models;
 
 namespace Devantler.Commons.CodeGen.CSharp;
 
 /// <summary>
 ///     A code generator for C#.
 /// </summary>
-public class CSharpCodeGenerator : ICodeGenerator<CSharpCompilation>
+public class CSharpCodeGenerator : ICodeGenerator
 {
     /// <inheritdoc />
-    public Dictionary<string, string> Generate(CSharpCompilation compilation) => compilation.Compile();
+    public Dictionary<string, string> Generate(ICompilation compilation) => compilation.Compile();
 }

--- a/src/Devantler.Commons.CodeGen.CSharp/Devantler.Commons.CodeGen.CSharp.csproj
+++ b/src/Devantler.Commons.CodeGen.CSharp/Devantler.Commons.CodeGen.CSharp.csproj
@@ -9,7 +9,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <PackageId>Devantler.Commons.CodeGen.CSharp</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>devantler</Authors>
         <Company>Devantler Software</Company>
         <PackageDescription>A code generator that can generate CSharp code.</PackageDescription>

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpConstructor.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpConstructor.cs
@@ -13,6 +13,9 @@ public class CSharpConstructor : ConstructorBase
     {
     }
 
+    /// <summary>
+    /// The template for a C# constructor.
+    /// </summary>
     public static string Template =>
         """
         {{ if $1.doc_block }}{{ include 'doc_block' $1.doc_block }}{{ end ~}}

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpDocBlockParameter.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpDocBlockParameter.cs
@@ -16,6 +16,9 @@ public class CSharpDocBlockParameter : DocBlockParameterBase
     {
     }
 
+    /// <summary>
+    /// The template for a C# documentation block parameter.
+    /// </summary>
     public static string Template =>
         """<param name="{{ $1.name }}">{{ $1.description }}</param>""";
 }

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpEnum.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpEnum.cs
@@ -39,6 +39,9 @@ public class CSharpEnum : EnumBase
         return template.Render(context);
     }
 
+    /// <summary>
+    /// The template for a C# enum.
+    /// </summary>
     public static string Template =>
         """
         {{- for using in imports ~}}

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpEnumSymbol.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpEnumSymbol.cs
@@ -24,6 +24,9 @@ public class CSharpEnumSymbol : EnumValueBase
     {
     }
 
+    /// <summary>
+    /// The template for a C# enum value.
+    /// </summary>
     public static string Template =>
         """
         {{ $1.name }}{{ if !($1.value | string.empty) }} = {{ $1.value }}{{ end }}

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpInterface.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpInterface.cs
@@ -40,6 +40,9 @@ public class CSharpInterface : InterfaceBase
         return template.Render(context);
     }
 
+    /// <summary>
+    /// The template for a C# interface.
+    /// </summary>
     public static string Template =>
         """
         {{- for using in imports ~}}

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpMethod.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpMethod.cs
@@ -21,6 +21,9 @@ public class CSharpMethod : MethodBase
     {
     }
 
+    /// <summary>
+    /// The template for a C# method.
+    /// </summary>
     public static string Template =>
         """
         {{ if $1.doc_block }}{{ include 'doc_block' $1.doc_block }}{{ end ~}}

--- a/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpParameter.cs
+++ b/src/Devantler.Commons.CodeGen.CSharp/Models/CSharpParameter.cs
@@ -16,5 +16,8 @@ public class CSharpParameter : ParameterBase
     {
     }
 
+    /// <summary>
+    /// The template for a C# parameter.
+    /// </summary>
     public static string Template => """{{ parameter.type }} {{ parameter.name }}""";
 }

--- a/src/Devantler.Commons.CodeGen.Core/Devantler.Commons.CodeGen.Core.csproj
+++ b/src/Devantler.Commons.CodeGen.Core/Devantler.Commons.CodeGen.Core.csproj
@@ -9,7 +9,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <PackageId>Devantler.Commons.CodeGen.Core</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>devantler</Authors>
         <Company>Devantler Software</Company>
         <PackageDescription>Core files used to build code generators and code collection mappers.</PackageDescription>

--- a/src/Devantler.Commons.CodeGen.Core/Interfaces/ICodeGenerator.cs
+++ b/src/Devantler.Commons.CodeGen.Core/Interfaces/ICodeGenerator.cs
@@ -3,13 +3,12 @@ namespace Devantler.Commons.CodeGen.Core.Interfaces;
 /// <summary>
 ///     An interface representing a code generator.
 /// </summary>
-/// <typeparam name="T"></typeparam>
-public interface ICodeGenerator<T> where T : ICompilation
+public interface ICodeGenerator
 {
     /// <summary>
     ///     Generates code from the given code base.
     /// </summary>
     /// <param name="compilation"></param>
     /// <returns>Dictionary&lt;fileName, code&gt;</returns>
-    public Dictionary<string, string> Generate(T compilation);
+    public Dictionary<string, string> Generate(ICompilation compilation);
 }

--- a/src/Devantler.Commons.CodeGen.Mapping.Avro/Devantler.Commons.CodeGen.Mapping.Avro.csproj
+++ b/src/Devantler.Commons.CodeGen.Mapping.Avro/Devantler.Commons.CodeGen.Mapping.Avro.csproj
@@ -9,7 +9,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <PackageId>Devantler.Commons.CodeGen.Mapping.Avro</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>devantler</Authors>
         <Company>Devantler Software</Company>
         <PackageDescription>A mapper to maps Avro Schemas to a compilation that can be generated.</PackageDescription>

--- a/src/Devantler.Commons.StringHelpers/Devantler.Commons.StringHelpers.csproj
+++ b/src/Devantler.Commons.StringHelpers/Devantler.Commons.StringHelpers.csproj
@@ -9,7 +9,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <PackageId>Devantler.Commons.StringHelpers</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>devantler</Authors>
         <Company>Devantler Software</Company>
         <PackageDescription>A collection of classes, extensions, and methods for working with strings.</PackageDescription>

--- a/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/CSharpTemplateLoaderTests.cs
+++ b/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/CSharpTemplateLoaderTests.cs
@@ -19,5 +19,4 @@ public class CSharpTemplateLoaderTests
         // Assert
         _ = template.Should().NotBeEmpty();
     }
-
 }


### PR DESCRIPTION
The change requires less casting and allows code-generating cross-language compilations, which might be useful in the future.

The change will require more error handling to ensure that specific language can compile if missing info, which might be tied to that specific languages implementation.