### PR TITLE
Remove FluentAssertions dependency and update Verify.XUnit version

### DIFF
--- a/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/AutoNSubstituteDataAttributeTests.cs
+++ b/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/AutoNSubstituteDataAttributeTests.cs
@@ -11,7 +11,7 @@ public class AutoNSubstituteDataAttributeTests
         var fixture = sut.Fixture;
 
         // Assert
-        _ = fixture.Customizations.Should().NotBeEmpty();
+        Assert.NotEmpty(fixture.Customizations);
     }
 
     [Fact]
@@ -24,6 +24,6 @@ public class AutoNSubstituteDataAttributeTests
         var fixture = sut.Fixture;
 
         // Assert
-        _ = fixture.Customizations.Should().NotBeEmpty();
+        Assert.NotEmpty(fixture.Customizations);
     }
 }

--- a/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit/Devantler.Commons.AutoFixture.DataAttributes.Tests.Unit.csproj
@@ -14,7 +14,6 @@
         <Using Include="AutoFixture.AutoNSubstitute" />
         <Using Include="AutoFixture.Xunit2" />
         <Using Include="AutoFixture" />
-        <Using Include="FluentAssertions" />
         <Using Include="NSubstitute" />
         <Using Include="Xunit" />
     </ItemGroup>
@@ -24,13 +23,12 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="AutoFixture" Version="4.18.0" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
-        <PackageReference Include="Verify.XUnit" Version="19.12.3" />
+        <PackageReference Include="Verify.XUnit" Version="19.13.0" />
+        <PackageReference Include="xunit.analyzers" Version="1.1.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
         <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>

--- a/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/CSharpTemplateLoaderTests.cs
+++ b/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/CSharpTemplateLoaderTests.cs
@@ -17,6 +17,6 @@ public class CSharpTemplateLoaderTests
         string template = await sut.LoadAsync(context, sourceSpan, typeof(CSharpClass).FullName ?? string.Empty);
 
         // Assert
-        _ = template.Should().NotBeEmpty();
+        Assert.NotEmpty(template);
     }
 }

--- a/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/Devantler.Commons.CodeGen.CSharp.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/Devantler.Commons.CodeGen.CSharp.Tests.Unit.csproj
@@ -14,7 +14,6 @@
         <Using Include="AutoFixture.AutoNSubstitute" />
         <Using Include="AutoFixture.Xunit2" />
         <Using Include="AutoFixture" />
-        <Using Include="FluentAssertions" />
         <Using Include="NSubstitute" />
         <Using Include="Xunit" />
     </ItemGroup>
@@ -24,13 +23,12 @@
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="AutoFixture" Version="4.18.0" />
         <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
-        <PackageReference Include="Verify.XUnit" Version="19.12.3" />
+        <PackageReference Include="Verify.XUnit" Version="19.13.0" />
+        <PackageReference Include="xunit.analyzers" Version="1.1.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
         <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
@@ -38,10 +36,6 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Devantler.Commons.CodeGen.CSharp\Devantler.Commons.CodeGen.CSharp.csproj" />
         <ProjectReference Include="..\..\src\Devantler.Commons.AutoFixture.DataAttributes\Devantler.Commons.AutoFixture.DataAttributes.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <AdditionalFiles Include="BannedSymbols.txt" />
     </ItemGroup>
 
 </Project>

--- a/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/Model/CSharpEnumSymbolTests.cs
+++ b/tests/Devantler.Commons.CodeGen.CSharp.Tests.Unit/Model/CSharpEnumSymbolTests.cs
@@ -14,7 +14,7 @@ public class CSharpEnumSymbolTests
         _ = sut.SetValue(TestValue.TestMember);
 
         // Assert
-        _ = sut.Value.Should().Be("TestMember");
+        Assert.Equal("TestMember", sut.Value);
     }
 
     public enum TestValue

--- a/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/Devantler.Commons.CodeGen.Core.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/Devantler.Commons.CodeGen.Core.Tests.Unit.csproj
@@ -14,7 +14,6 @@
     <Using Include="AutoFixture.AutoNSubstitute" />
     <Using Include="AutoFixture.Xunit2" />
     <Using Include="AutoFixture" />
-    <Using Include="FluentAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>
@@ -24,13 +23,12 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
-    <PackageReference Include="Verify.XUnit" Version="19.12.3" />
+    <PackageReference Include="Verify.XUnit" Version="19.13.0" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
@@ -42,10 +40,6 @@
 
   <ItemGroup>
     <Content Include="templates/**/*" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>
 
 </Project>

--- a/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/FileTemplateLoaderTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/FileTemplateLoaderTests.cs
@@ -17,7 +17,7 @@ public class FileTemplateLoaderTests
         string result = sut.GetPath(context, sourceSpan, "test-template.sbn");
 
         // Assert
-        _ = result.Should().Be($"{Directory.GetCurrentDirectory()}/templates/test-template.sbn");
+        Assert.Equal($"{Directory.GetCurrentDirectory()}/templates/test-template.sbn", result);
     }
 
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
@@ -31,7 +31,7 @@ public class FileTemplateLoaderTests
         string result = sut.Load(context, sourceSpan, path);
 
         // Assert
-        _ = result.Should().Be("This is a test template.");
+        Assert.Equal("This is a test template.", result);
     }
 
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
@@ -42,10 +42,10 @@ public class FileTemplateLoaderTests
         string path = $"{Directory.GetCurrentDirectory()}/templates/invalid-template.sbn";
 
         // Act
-        Action action = () => sut.Load(context, sourceSpan, path);
+        void action() => sut.Load(context, sourceSpan, path);
 
         // Assert
-        _ = action.Should().Throw<FileNotFoundException>();
+        _ = Assert.Throws<FileNotFoundException>(action);
     }
 
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
@@ -59,7 +59,7 @@ public class FileTemplateLoaderTests
         string result = await sut.LoadAsync(context, sourceSpan, path);
 
         // Assert
-        _ = result.Should().Be("This is a test template.");
+        Assert.Equal("This is a test template.", result);
     }
 
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
@@ -70,9 +70,9 @@ public class FileTemplateLoaderTests
         string path = $"{Directory.GetCurrentDirectory()}/templates/invalid-template.sbn";
 
         // Act
-        Func<Task> action = async () => await sut.LoadAsync(context, sourceSpan, path);
+        async Task action() => await sut.LoadAsync(context, sourceSpan, path);
 
         // Assert
-        _ = action.Should().ThrowAsync<FileNotFoundException>();
+        _ = Assert.ThrowsAsync<FileNotFoundException>(action);
     }
 }

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/AvroSchemaTypeParserTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/AvroSchemaTypeParserTests.cs
@@ -15,7 +15,7 @@ public class AvroSchemaTypeParserTests
         string actual = parser.Parse(field.Type, language, x => x.RecordSuffix = options?.RecordSuffix ?? string.Empty);
 
         // Assert
-        _ = actual.Should().Be(expected);
+        Assert.Equal(expected, actual);
     }
 
     [Theory, MemberData(nameof(TestCases.InvalidCases), MemberType = typeof(TestCases))]
@@ -25,9 +25,9 @@ public class AvroSchemaTypeParserTests
         var parser = new AvroSchemaParser();
 
         // Act
-        Action actual = () => parser.Parse(field.Type, language);
+        void actual() => parser.Parse(field.Type, language);
 
         // Assert
-        _ = actual.Should().Throw<NotSupportedException>();
+        _ = Assert.Throws<NotSupportedException>(actual);
     }
 }

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit.csproj
@@ -14,7 +14,6 @@
       <Using Include="AutoFixture.AutoNSubstitute" />
       <Using Include="AutoFixture.Xunit2" />
       <Using Include="AutoFixture" />
-      <Using Include="FluentAssertions" />
       <Using Include="NSubstitute" />
       <Using Include="Xunit" />
   </ItemGroup>
@@ -24,23 +23,18 @@
       <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
       <PackageReference Include="AutoFixture" Version="4.18.0" />
       <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
-      <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-      <PackageReference Include="FluentAssertions" Version="6.11.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="NSubstitute" Version="5.0.0" />
       <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
       <PackageReference Include="Verify.XUnit" Version="19.12.3" />
+      <PackageReference Include="xunit.analyzers" Version="1.1.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
       <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>
       <ProjectReference Include="..\..\src\Devantler.Commons.CodeGen.Mapping.Avro\Devantler.Commons.CodeGen.Mapping.Avro.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-      <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>
 
 </Project>

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Mappers/AvroEntitiesCompilationMapperTests/MapTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Mappers/AvroEntitiesCompilationMapperTests/MapTests.cs
@@ -33,6 +33,6 @@ public class MapTests
         var action = () => mapper.Map(schemaBuilder.BuildSchema<RecordSchema>(), language);
 
         // Assert
-        _ = action.Should().Throw<NotSupportedException>();
+        _ = Assert.Throws<NotSupportedException>(action);
     }
 }

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Mappers/AvroModelsCompilationMapperTests/MapTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/Mappers/AvroModelsCompilationMapperTests/MapTests.cs
@@ -33,6 +33,6 @@ public class MapTests
         var action = () => mapper.Map(schemaBuilder.BuildSchema<RecordSchema>(), language);
 
         // Assert
-        _ = action.Should().Throw<NotSupportedException>();
+        _ = Assert.Throws<NotSupportedException>(action);
     }
 }

--- a/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/SchemaExtensionTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Mapping.Avro.Tests.Unit/SchemaExtensionTests.cs
@@ -55,7 +55,7 @@ public class SchemaExtensionTests
         var result = rootSchema.Flatten();
 
         // Assert
-        _ = result.Should().HaveCount(5);
-        _ = result.Should().AllSatisfy(schema => (schema is RecordSchema || schema is EnumSchema).Should().BeTrue());
+        Assert.Equal(5, result.Count);
+        Assert.True(result.All(schema => schema is RecordSchema or EnumSchema));
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/BannedSymbols.txt
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:Xunit.Assert;Use 'FluentAssertions' instead.

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Devantler.Commons.StringHelpers.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Devantler.Commons.StringHelpers.Tests.Unit.csproj
@@ -8,34 +8,28 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="AutoFixture.AutoNSubstitute"/>
-        <Using Include="AutoFixture.Xunit2"/>
-        <Using Include="AutoFixture"/>
-        <Using Include="FluentAssertions"/>
-        <Using Include="NSubstitute"/>
-        <Using Include="Xunit"/>
+        <Using Include="AutoFixture.AutoNSubstitute" />
+        <Using Include="AutoFixture.Xunit2" />
+        <Using Include="AutoFixture" />
+        <Using Include="NSubstitute" />
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0"/>
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0"/>
-        <PackageReference Include="AutoFixture" Version="4.18.0"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all"/>
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2"/>
-        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
-        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16"/>
-        <PackageReference Include="NSubstitute" Version="5.0.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+        <PackageReference Include="AutoFixture" Version="4.18.0" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
+        <PackageReference Include="xunit.analyzers" Version="1.1.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+        <PackageReference Include="xunit" Version="2.4.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Devantler.Commons.StringHelpers\Devantler.Commons.StringHelpers.csproj"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <AdditionalFiles Include="BannedSymbols.txt"/>
+        <ProjectReference Include="..\..\src\Devantler.Commons.StringHelpers\Devantler.Commons.StringHelpers.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToCamelCaseTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToCamelCaseTests.cs
@@ -13,6 +13,6 @@ public class ToCamelCaseTests
         string actual = text.ToCamelCase();
 
         //Assert
-        _ = RegexLibrary.CamelCaseWithDigitsRegex.IsMatch(actual).Should().BeTrue();
+        Assert.Matches(RegexLibrary.CamelCaseWithDigitsRegex, actual);
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToKebabCaseTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToKebabCaseTests.cs
@@ -13,6 +13,6 @@ public class ToKebabCaseTests
         string actual = text.ToKebabCase();
 
         //Assert
-        _ = RegexLibrary.KebabCaseRegex.IsMatch(actual).Should().BeTrue();
+        Assert.Matches(RegexLibrary.KebabCaseRegex, actual);
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToPascalCaseTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/CasingStringExtensionsTests/ToPascalCaseTests.cs
@@ -13,6 +13,6 @@ public class ToPascalCaseTests
         string actual = text.ToPascalCase();
 
         //Assert
-        _ = RegexLibrary.PascalCaseWithDigitsRegex.IsMatch(actual).Should().BeTrue();
+        Assert.Matches(RegexLibrary.PascalCaseWithDigitsRegex, actual);
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/FormattingStringExtensionsTests/IndentTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/FormattingStringExtensionsTests/IndentTests.cs
@@ -13,7 +13,7 @@ public class IndentTests
         string actual = text.Indent(indentSize);
 
         //Assert
-        _ = actual.Should().StartWith(new string(' ', indentSize));
+        Assert.StartsWith(new string(' ', indentSize), actual);
     }
 
     [Fact]
@@ -29,8 +29,9 @@ public class IndentTests
         string actual = multiLineText.Indent(4, true);
 
         //Assert
-        _ = actual.Should().StartWith("first line");
-        _ = actual.Should().EndWith("    second line");
+        Assert.StartsWith("first line", actual);
+        Assert.EndsWith("    second line", actual);
+
     }
 
     [Theory]
@@ -46,8 +47,7 @@ public class IndentTests
         string actual = multiLineText.Indent(indentSize);
 
         //Assert
-        _ = actual.Split(Environment.NewLine).Should()
-            .OnlyContain(line => line.StartsWith(new string(' ', indentSize)));
+        Assert.All(actual.Split(Environment.NewLine), line => Assert.StartsWith(new string(' ', indentSize), line));
     }
 
     [Theory]
@@ -55,9 +55,9 @@ public class IndentTests
     public void GivenSingleLineTextAndNegativeIndentSize_Throws([Range(-100, -1)] int indentSize)
     {
         //Act
-        Action action = () => "this is a test".Indent(indentSize);
+        void action() => "this is a test".Indent(indentSize);
 
         //Assert
-        _ = action.Should().Throw<ArgumentOutOfRangeException>();
+        _ = Assert.Throws<ArgumentOutOfRangeException>(action);
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/GeneralStringExtensionsTests/NullIfEmptyTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/GeneralStringExtensionsTests/NullIfEmptyTests.cs
@@ -13,7 +13,7 @@ public class GeneralStringExtensionsTests
         string? actual = input.NullIfEmpty();
 
         // Assert
-        _ = actual.Should().BeNull();
+        Assert.Null(actual);
     }
 
     [Theory]
@@ -26,6 +26,6 @@ public class GeneralStringExtensionsTests
         string? actual = input.NullIfEmpty();
 
         // Assert
-        _ = actual.Should().Be(input);
+        Assert.Equal(input, actual);
     }
 }

--- a/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/GrammarStringExtensionsTests/ToPluralTests.cs
+++ b/tests/Devantler.Commons.StringHelpers.Tests.Unit/Extensions/GrammarStringExtensionsTests/ToPluralTests.cs
@@ -28,6 +28,6 @@ public class ToPluralTests
         string actual = input.ToPlural();
 
         // Assert
-        _ = actual.Should().Be(expected);
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
The changes remove FluentAssertions from the C# code generation and Data Attributes test projects and update the Verify.XUnit package version. The commit includes minor changes such as using Assert instead of FluentAssertions and removing the BannedSymbols.txt file. The changes also include removing the Verify.XUnit and the Microsoft.NET.Test.Sdk packages from the core code generation project.