### PR TITLE
Add GenerateDocumentationFile property and unit tests for FileTemplateLoader class

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,6 +22,6 @@ jobs:
       - name: Upload Code Coverage to CodeCov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/**/TestResults/**/coverage.cobertura.xml
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/Devantler.Commons.CodeGen.Core.Tests.Unit.csproj
+++ b/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/Devantler.Commons.CodeGen.Core.Tests.Unit.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
 
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -23,7 +24,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
-    
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />

--- a/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/FileTemplateLoaderTests.cs
+++ b/tests/Devantler.Commons.CodeGen.Core.Tests.Unit/FileTemplateLoaderTests.cs
@@ -5,8 +5,16 @@ using Scriban.Parsing;
 
 namespace Devantler.Commons.CodeGen.Core.Tests.Unit;
 
+/// <summary>
+/// Unit tests for the <see cref="FileTemplateLoader"/> class.
+/// </summary>
 public class FileTemplateLoaderTests
 {
+    /// <summary>
+    /// Tests if the GetPath method returns a valid path when given a template name.
+    /// </summary>
+    /// <param name="context">The template context.</param>
+    /// <param name="sourceSpan">The source span.</param>
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
     public void GetPath_GivenTemplateName_ReturnsValidPath(TemplateContext context, SourceSpan sourceSpan)
     {
@@ -20,6 +28,11 @@ public class FileTemplateLoaderTests
         Assert.Equal($"{Directory.GetCurrentDirectory()}/templates/test-template.sbn", result);
     }
 
+    /// <summary>
+    /// Tests the Load method of the FileTemplateLoader class when given a valid path and ensures that it returns the contents of the file.
+    /// </summary>
+    /// <param name="context">The template context to use for loading the file.</param>
+    /// <param name="sourceSpan">The source span to use for loading the file.</param>
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
     public void Load_GivenValidPath_ReturnsFileContents(TemplateContext context, SourceSpan sourceSpan)
     {
@@ -34,6 +47,11 @@ public class FileTemplateLoaderTests
         Assert.Equal("This is a test template.", result);
     }
 
+    /// <summary>
+    /// Tests that an exception is thrown when attempting to load a template from an invalid file path.
+    /// </summary>
+    /// <param name="context">The template context.</param>
+    /// <param name="sourceSpan">The source span.</param>
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
     public void Load_GivenInvalidPath_ThrowsFileNotFoundException(TemplateContext context, SourceSpan sourceSpan)
     {
@@ -48,6 +66,12 @@ public class FileTemplateLoaderTests
         _ = Assert.Throws<FileNotFoundException>(action);
     }
 
+    /// <summary>
+    /// Tests that LoadAsync returns the contents of the file when given a valid path.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="sourceSpan"></param>
+    /// <returns></returns>
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
     public async Task LoadAsync_GivenValidPath_ReturnsFileContents(TemplateContext context, SourceSpan sourceSpan)
     {
@@ -62,8 +86,14 @@ public class FileTemplateLoaderTests
         Assert.Equal("This is a test template.", result);
     }
 
+    /// <summary>
+    /// Tests that LoadAsync throws a FileNotFoundException when given an invalid path.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="sourceSpan"></param>
+    /// <returns></returns>
     [Theory, AutoNSubstituteData(typeof(SupportMutableValueTypesCustomization))]
-    public void LoadAsync_GivenInvalidPath_ThrowsFileNotFoundException(TemplateContext context, SourceSpan sourceSpan)
+    public async Task LoadAsync_GivenInvalidPath_ThrowsFileNotFoundException(TemplateContext context, SourceSpan sourceSpan)
     {
         // Arrange
         var sut = new FileTemplateLoader();
@@ -73,6 +103,6 @@ public class FileTemplateLoaderTests
         async Task action() => await sut.LoadAsync(context, sourceSpan, path);
 
         // Assert
-        _ = Assert.ThrowsAsync<FileNotFoundException>(action);
+        _ = await Assert.ThrowsAsync<FileNotFoundException>(action);
     }
 }


### PR DESCRIPTION
This pull request adds the GenerateDocumentationFile property to the Devantler.Commons.CodeGen.Core.Tests.Unit.csproj file and updates the package references. It also includes unit tests for the FileTemplateLoader class, testing the GetPath and Load methods with valid and invalid paths.