### PR TITLE
Add Devantler.Commons.Utils library with TimeSpan parsing functionality

### DIFF
--- a/Devantler.Commons.sln
+++ b/Devantler.Commons.sln
@@ -15,6 +15,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.Commons.Extension
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.Commons.Extensions.Tests", "tests\Devantler.Commons.Extensions.Tests\Devantler.Commons.Extensions.Tests.csproj", "{5D51F1E3-614B-4994-BAD8-3DAFB2273251}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.Commons.Utils", "src\Devantler.Commons.Utils\Devantler.Commons.Utils.csproj", "{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devantler.Commons.Utils.Tests", "tests\Devantler.Commons.Utils.Tests\Devantler.Commons.Utils.Tests.csproj", "{0B846C25-B403-40EC-8DAC-FCC8D272C152}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +77,30 @@ Global
 		{5D51F1E3-614B-4994-BAD8-3DAFB2273251}.Release|x64.Build.0 = Release|Any CPU
 		{5D51F1E3-614B-4994-BAD8-3DAFB2273251}.Release|x86.ActiveCfg = Release|Any CPU
 		{5D51F1E3-614B-4994-BAD8-3DAFB2273251}.Release|x86.Build.0 = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|x64.Build.0 = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA}.Release|x86.Build.0 = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|x64.Build.0 = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Debug|x86.Build.0 = Debug|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|x64.ActiveCfg = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|x64.Build.0 = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|x86.ActiveCfg = Release|Any CPU
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,5 +110,7 @@ Global
 		{DC29E51D-304F-441E-B96C-7EC91E4B7E70} = {72326D0F-9CD1-4424-A12B-D3B5DCC0649D}
 		{B7356069-7A34-4A9B-BAC8-F6E2C94F1D57} = {A9435505-9972-4D9C-BEE4-DCC8DCAB290F}
 		{5D51F1E3-614B-4994-BAD8-3DAFB2273251} = {72326D0F-9CD1-4424-A12B-D3B5DCC0649D}
+		{2A9CEEAB-34BA-4525-83F2-E8537791D2DA} = {A9435505-9972-4D9C-BEE4-DCC8DCAB290F}
+		{0B846C25-B403-40EC-8DAC-FCC8D272C152} = {72326D0F-9CD1-4424-A12B-D3B5DCC0649D}
 	EndGlobalSection
 EndGlobal

--- a/src/Devantler.Commons.Utils/Devantler.Commons.Utils.csproj
+++ b/src/Devantler.Commons.Utils/Devantler.Commons.Utils.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>preview-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/src/Devantler.Commons.Utils/TimeSpanHelper.cs
+++ b/src/Devantler.Commons.Utils/TimeSpanHelper.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Devantler.Commons.Utils;
+
+/// <summary>
+/// Helper class for <see cref="TimeSpan"/>.
+/// </summary>
+public static class TimeSpanHelper
+{
+  static readonly List<(string Abbreviation, TimeSpan InitialTimeSpan)> _timeSpanInfos =
+  [
+          ("y", TimeSpan.FromDays(365)), // Year
+          ("M", TimeSpan.FromDays(30)), // Month
+          ("w", TimeSpan.FromDays(7)), // Week
+          ("d", TimeSpan.FromDays(1)), // Day
+          ("h", TimeSpan.FromHours(1)), // Hour
+          ("m", TimeSpan.FromMinutes(1)), // Minute
+          ("s", TimeSpan.FromSeconds(1)), // Second
+          ("t", TimeSpan.FromTicks(1)) // Tick
+  ];
+
+  /// <summary>
+  /// Parse a duration string into a <see cref="TimeSpan"/>.
+  /// </summary>
+  /// <param name="format"></param>
+  /// <returns></returns>
+  public static TimeSpan ParseDuration(string format)
+  {
+    var result = _timeSpanInfos
+        .Where(timeSpanInfo => format.Contains(timeSpanInfo.Abbreviation, StringComparison.Ordinal))
+        .Select(timeSpanInfo => timeSpanInfo.InitialTimeSpan * int.Parse(new Regex(@$"(\d+){timeSpanInfo.Abbreviation}").Match(format).Groups[1].Value, CultureInfo.InvariantCulture))
+        .Aggregate((accumulator, timeSpan) => accumulator + timeSpan);
+    return result;
+  }
+}

--- a/src/Devantler.Commons.Utils/TimeSpanHelper.cs
+++ b/src/Devantler.Commons.Utils/TimeSpanHelper.cs
@@ -28,9 +28,9 @@ public static class TimeSpanHelper
   public static TimeSpan ParseDuration(string format)
   {
     var result = _timeSpanInfos
-        .Where(timeSpanInfo => format.Contains(timeSpanInfo.Abbreviation, StringComparison.Ordinal))
-        .Select(timeSpanInfo => timeSpanInfo.InitialTimeSpan * int.Parse(new Regex(@$"(\d+){timeSpanInfo.Abbreviation}").Match(format).Groups[1].Value, CultureInfo.InvariantCulture))
-        .Aggregate((accumulator, timeSpan) => accumulator + timeSpan);
+      .Where(timeSpanInfo => format.Contains(timeSpanInfo.Abbreviation, StringComparison.Ordinal))
+      .Select(timeSpanInfo => timeSpanInfo.InitialTimeSpan * int.Parse(new Regex(@$"(\d+){timeSpanInfo.Abbreviation}").Match(format).Groups[1].Value, CultureInfo.InvariantCulture))
+      .Aggregate((accumulator, timeSpan) => accumulator + timeSpan);
     return result;
   }
 }

--- a/tests/Devantler.Commons.Utils.Tests/Devantler.Commons.Utils.Tests.csproj
+++ b/tests/Devantler.Commons.Utils.Tests/Devantler.Commons.Utils.Tests.csproj
@@ -19,20 +19,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.19.0" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Devantler.Commons.Extensions\Devantler.Commons.Extensions.csproj" />
+    <ProjectReference Include="..\..\src\Devantler.Commons.Utils\Devantler.Commons.Utils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Devantler.Commons.Utils.Tests/TimeSpanHelperTest.cs
+++ b/tests/Devantler.Commons.Utils.Tests/TimeSpanHelperTest.cs
@@ -42,6 +42,5 @@ public class TimeSpanHelperTest
   [InlineData("")]
   [InlineData("1x")]
   public void ParseDuration_InvalidFormat_ThrowsException(string format) =>
-    // Act & Assert
     Assert.ThrowsAny<Exception>(() => TimeSpanHelper.ParseDuration(format));
 }

--- a/tests/Devantler.Commons.Utils.Tests/TimeSpanHelperTest.cs
+++ b/tests/Devantler.Commons.Utils.Tests/TimeSpanHelperTest.cs
@@ -1,0 +1,47 @@
+﻿namespace Devantler.Commons.Utils.Tests;
+
+/// <summary>
+/// Tests for <see cref="TimeSpanHelper"/>.
+/// </summary>
+public class TimeSpanHelperTest
+{
+  /// <summary>
+  /// Test cases for <see cref="TimeSpanHelper.ParseDuration"/>.
+  /// </summary>
+  /// <param name="format"></param>
+  /// <param name="days"></param>
+  /// <param name="hours"></param>
+  /// <param name="minutes"></param>
+  /// <param name="seconds"></param>
+  /// <param name="ticks"></param>
+  [Theory]
+  [InlineData("1y", 365, 0, 0, 0, 0)]
+  [InlineData("1M", 30, 0, 0, 0, 0)]
+  [InlineData("1w", 7, 0, 0, 0, 0)]
+  [InlineData("1d", 1, 0, 0, 0, 0)]
+  [InlineData("1h", 0, 1, 0, 0, 0)]
+  [InlineData("1m", 0, 0, 1, 0, 0)]
+  [InlineData("1s", 0, 0, 0, 1, 0)]
+  [InlineData("1t", 0, 0, 0, 0, 1)]
+  [InlineData("1y1M1w1d1h1m1s1t", 365 + 30 + 7 + 1, 1, 1, 1, 1)]
+  public void ParseDuration_ValidFormat_ReturnsExpectedTimeSpan(string format, int days, int hours, int minutes, int seconds, long ticks)
+  {
+    // Act
+    var result = TimeSpanHelper.ParseDuration(format);
+
+    // Assert
+    var expected = new TimeSpan(days, hours, minutes, seconds, 0).Add(TimeSpan.FromTicks(ticks));
+    Assert.Equal(expected, result);
+  }
+
+  /// <summary>
+  /// Test cases for <see cref="TimeSpanHelper.ParseDuration"/>.
+  /// </summary>
+  /// <param name="format"></param>
+  [Theory]
+  [InlineData("")]
+  [InlineData("1x")]
+  public void ParseDuration_InvalidFormat_ThrowsException(string format) =>
+    // Act & Assert
+    Assert.ThrowsAny<Exception>(() => TimeSpanHelper.ParseDuration(format));
+}


### PR DESCRIPTION
Introduce a new library and a helper class for parsing duration strings into TimeSpan objects, along with corresponding unit tests.